### PR TITLE
No advantage of permutations over combinations

### DIFF
--- a/mp3treesim/mp3treesim.py
+++ b/mp3treesim/mp3treesim.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
-from itertools import permutations, combinations
+from itertools import combinations
 from collections import defaultdict, Counter
 
 import networkx as nx
@@ -193,7 +193,7 @@ def similarity(tree1, tree2, mode='sigmoid', sigmoid_mult=10.0):
     else:
         labels = set(tree1.label_set) | set(tree2.label_set)
 
-    for triple in permutations(labels, 3):
+    for triple in combinations(labels, 3):
         missing, num, dem = is_equal_struct(triple, tree1.LCA, tree2.LCA)
         numerator += num
         if missing:


### PR DESCRIPTION
The permutations include repeated triplets with different labels ordering, which is irrelevant in distance evaluation.
The example in the readme file runs 35% faster giving the same output.